### PR TITLE
iOS 13 support

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -6,13 +6,13 @@ using Cake.Common.Build.TeamCity.Data;
 var target = Argument("target", Argument ("t", "Default"));
 
 var buildNumber = EnvironmentVariable("BUILD_BUILDNUMBER") ?? "0";
-var nugetVersion = $"3.2.{buildNumber}";
+var nugetVersion = $"3.3.{buildNumber}";
 
 var externalVersions = new
 {
     RxAndroid = "1.2.1",
     RxJava = "1.1.6",
-    CurbsideIos = "3.27",
+    CurbsideIos = "3.30",
     CurbsideAndroid = "3.2.4"
 };
 

--- a/samples/CurbsideAndroidSample/Resources/Resource.designer.cs
+++ b/samples/CurbsideAndroidSample/Resources/Resource.designer.cs
@@ -2703,6 +2703,9 @@ namespace CurbsideAndroidSample
 		public partial class String
 		{
 			
+			// aapt resource value: 0x7f06003b
+			public const int KEY_TRACKING_ID = 2131099707;
+			
 			// aapt resource value: 0x7f06001b
 			public const int abc_action_bar_home_description = 2131099675;
 			
@@ -2868,8 +2871,8 @@ namespace CurbsideAndroidSample
 			// aapt resource value: 0x7f060006
 			public const int google_storage_bucket = 2131099654;
 			
-			// aapt resource value: 0x7f06003b
-			public const int hello = 2131099707;
+			// aapt resource value: 0x7f06003e
+			public const int hello = 2131099710;
 			
 			// aapt resource value: 0x7f06003a
 			public const int library_name = 2131099706;
@@ -2879,6 +2882,9 @@ namespace CurbsideAndroidSample
 			
 			// aapt resource value: 0x7f060008
 			public const int place_autocomplete_search_hint = 2131099656;
+			
+			// aapt resource value: 0x7f06003d
+			public const int pref_api_host_key = 2131099709;
 			
 			// aapt resource value: 0x7f06002c
 			public const int search_menu_title = 2131099692;

--- a/samples/CurbsideiOSSample/ViewController.designer.cs
+++ b/samples/CurbsideiOSSample/ViewController.designer.cs
@@ -1,17 +1,20 @@
-﻿//
-// This file has been generated automatically by MonoDevelop to store outlets and
-// actions made in the Xcode designer. If it is removed, they will be lost.
-// Manual changes to this file may not be handled correctly.
+﻿// WARNING
+//
+// This file has been generated automatically by Visual Studio from the outlets and
+// actions declared in your storyboard file.
+// Manual changes to this file will not be maintained.
 //
 using Foundation;
+using System;
+using System.CodeDom.Compiler;
 
 namespace CurbsideiOSSample
 {
-	[Register("ViewController")]
-	partial class ViewController
-	{
-		void ReleaseDesignerOutlets()
-		{
-		}
-	}
+    [Register ("ViewController")]
+    partial class ViewController
+    {
+        void ReleaseDesignerOutlets ()
+        {
+        }
+    }
 }

--- a/src/Curbside.Xamarin.iOS/ApiDefinition.cs
+++ b/src/Curbside.Xamarin.iOS/ApiDefinition.cs
@@ -8,7 +8,27 @@ using WebKit;
 namespace Curbside
 {
 
-	// @interface CSSession : NSObject
+    [Static]
+    partial interface Constants
+    {
+        // extern NSString *const CSTripTypeCarryOut;
+        [Field("CSTripTypeCarryOut", "__Internal")]
+        NSString CSTripTypeCarryOut { get; }
+
+        // extern NSString *const CSTripTypeDriveThru;
+        [Field("CSTripTypeDriveThru", "__Internal")]
+        NSString CSTripTypeDriveThru { get; }
+
+        // extern NSString *const CSTripTypeCurbside;
+        [Field("CSTripTypeCurbside", "__Internal")]
+        NSString CSTripTypeCurbside { get; }
+
+        // extern NSString *const CSTripTypeDineIn;
+        [Field("CSTripTypeDineIn", "__Internal")]
+        NSString CSTripTypeDineIn { get; }
+    }
+
+    // @interface CSSession : NSObject
     [Protocol]
 	[BaseType(typeof(NSObject))]
 	interface CSSession
@@ -62,7 +82,6 @@ namespace Curbside
 	}
  
 	// @interface CSSite : NSObject
-
     [Protocol]
 	[BaseType(typeof(NSObject))]
 	interface CSSite : INativeObject
@@ -135,12 +154,32 @@ namespace Curbside
 		[Export("startTripToSiteWithIdentifier:trackToken:")]
 		void StartTripToSiteWithIdentifier(string siteId, string trackToken);
 
+        // -(void)startUserOnTheirWayTripToSiteWithIdentifier:(NSString * _Nonnull)siteID trackToken:(NSString * _Nonnull)trackToken;
+        [Export("startUserOnTheirWayTripToSiteWithIdentifier:trackToken:")]
+        void StartUserOnTheirWayTripToSiteWithIdentifier(string siteID, string trackToken);
+
         //- (void)startTripToSiteWithIdentifier:(NSString *)siteID trackToken:(NSString *)trackToken etaFromDate:(NSDate *)fromDate toDate:(nullable NSDate *)toDate;
         [Export("startTripToSiteWithIdentifier:trackToken:etaFromDate:toDate:")]
         void StartTripToSiteWithIdentifierWithEta(string siteId, string trackToken, NSDate fromDate, [NullAllowed]NSDate toDate);
 
+        // -(void)startTripToSiteWithIdentifier:(NSString * _Nonnull)siteID trackToken:(NSString * _Nonnull)trackToken tripType:(NSString * _Nonnull)tripType;
+        [Export("startTripToSiteWithIdentifier:trackToken:tripType:")]
+        void StartTripToSiteWithIdentifier(string siteID, string trackToken, string tripType);
+
+        // -(void)startUserOnTheirWayTripToSiteWithIdentifier:(NSString * _Nonnull)siteID trackToken:(NSString * _Nonnull)trackToken tripType:(NSString * _Nonnull)tripType;
+        [Export("startUserOnTheirWayTripToSiteWithIdentifier:trackToken:tripType:")]
+        void StartUserOnTheirWayTripToSiteWithIdentifier(string siteID, string trackToken, string tripType);
+
+        // -(void)startTripToSiteWithIdentifier:(NSString * _Nonnull)siteID trackToken:(NSString * _Nonnull)trackToken etaFromDate:(NSDate * _Nonnull)fromDate toDate:(NSDate * _Nullable)toDate tripType:(NSString * _Nonnull)tripType;
+        [Export("startTripToSiteWithIdentifier:trackToken:etaFromDate:toDate:tripType:")]
+        void StartTripToSiteWithIdentifier(string siteID, string trackToken, NSDate fromDate, [NullAllowed] NSDate toDate, string tripType);
+
+        // -(void)updateAllTripsWithUserOnTheirWay:(BOOL)userOnTheirWay;
+        [Export("updateAllTripsWithUserOnTheirWay:")]
+        void UpdateAllTripsWithUserOnTheirWay(bool userOnTheirWay);
+
         // - (void) completeTripToSiteWithIdentifier:(NSString*) trackingIdentifier trackToken:(nullable NSString*>) trackToken;
-		[Export("completeTripToSiteWithIdentifier:trackToken:")]
+        [Export("completeTripToSiteWithIdentifier:trackToken:")]
 		void CompleteTripToSiteWithIdentifier(string siteId, string trackToken);
 
         // - (void) cancelTripToSiteWithIdentifier:(NSString*) trackingIdentifier trackToken:(nullable NSString*>) trackToken;
@@ -304,8 +343,6 @@ namespace Curbside
 		void CompleteTripForTrackingIdentifier(string trackingIdentifier, string[] trackTokens);
 	}
 
-
-
 	// typedef void (^CSUserLocationUpdatesAvailableHandler)(NSArray *);
     delegate void CSUserStatusUpdatesAvailableHandler(CSUserStatusUpdate[] updates);
 
@@ -321,7 +358,6 @@ namespace Curbside
     }
 
     // @interface CSSiteArrivalTracker : NSObject
-
     [Protocol]
     [BaseType(typeof(NSObject))]
 	interface CSSiteArrivalTracker
@@ -401,12 +437,12 @@ namespace Curbside
 		[Export("userStatus")]
 		CSUserStatus UserStatus { get; }
 
-		// @property (readonly, nonatomic) CSCustomerInfo * customerInfo;
-		[Export("customerInfo")]
-		CSUserInfo CustomerInfo { get; }
+        // @property (readonly, nonatomic) CSUserInfo * _Nullable userInfo;
+        [Export("userInfo")]
+        CSUserInfo UserInfo { get; }
 
-		// @property (readonly, nonatomic) BOOL acknowledgedUser;
-		[Export("acknowledgedUser")]
+        // @property (readonly, nonatomic) BOOL acknowledgedUser;
+        [Export("acknowledgedUser")]
 		bool AcknowledgedUser { get; }
 
 		// @property (readonly, nonatomic) int estimatedTimeOfArrival;
@@ -421,95 +457,18 @@ namespace Curbside
         [Export("tripInfos")]
         CSTripInfo[] TripInfos { get; }
 
-		// -(void)opsAcknowledgesUserWithMessage:(NSString *)ackMessage handler:(CSUserAcknowledgeStatus)acknowledgeStatusHandler;
-		[Export("opsAcknowledgesUserWithMessage:handler:")]
-		void OpsAcknowledgesUserWithMessage(string ackMessage, CSUserAcknowledgeStatus acknowledgeStatusHandler);
+        // -(void)monitoringSessionUserAcknowledgesUserWithMessage:(NSString * _Nonnull)ackMessage handler:(CSUserAcknowledgeStatus _Nonnull)acknowledgeStatusHandler;
+        [Export("monitoringSessionUserAcknowledgesUserWithMessage:handler:")]
+        void MonitoringSessionUserAcknowledgesUserWithMessage(string ackMessage, CSUserAcknowledgeStatus acknowledgeStatusHandler);
 
-		// @property (readonly, nonatomic) NSDate * opsAcknowledgedTimestamp;
-		[Export("opsAcknowledgedTimestamp")]
-		NSDate OpsAcknowledgedTimestamp { get; }
+        // @property (readonly, nonatomic) NSDate * _Nullable monitoringSessionUserAcknowledgedTimestamp;
+        [Export("monitoringSessionUserAcknowledgedTimestamp")]
+        NSDate MonitoringSessionUserAcknowledgedTimestamp { get; }
 
-		// @property (readonly, nonatomic) NSString * opsTrackingIdentifier;
-		[Export("opsTrackingIdentifier")]
-		string OpsTrackingIdentifier { get; }
-	}
-
-	// @interface CSWebView : UIWebView
-    [Protocol]
-	[BaseType(typeof(UIWebView))]
-	interface CSWebView
-	{
-		// @property (nonatomic, strong) NSString * oauthToken;
-		[Export("oauthToken", ArgumentSemantic.Strong)]
-		string OauthToken { get; set; }
-
-		[Wrap("WeakLoginDelegate")]
-		CSWebViewLoginDelegate LoginDelegate { get; set; }
-
-		// @property (assign, nonatomic) id<CSWebViewLoginDelegate> loginDelegate;
-		[NullAllowed, Export("loginDelegate", ArgumentSemantic.Assign)]
-		NSObject WeakLoginDelegate { get; set; }
-
-		[Wrap("WeakAnalyticsDelegate")]
-		CSWebViewAnalyticsDelegate AnalyticsDelegate { get; set; }
-
-		// @property (assign, nonatomic) id<CSWebViewAnalyticsDelegate> analyticsDelegate;
-		[NullAllowed, Export("analyticsDelegate", ArgumentSemantic.Assign)]
-		NSObject WeakAnalyticsDelegate { get; set; }
-
-		// @property (nonatomic, strong) NSDictionary * requestContext;
-		[Export("requestContext", ArgumentSemantic.Strong)]
-		NSDictionary RequestContext { get; set; }
-
-		// @property (nonatomic) BOOL developmentMode;
-		[Export("developmentMode")]
-		bool DevelopmentMode { get; set; }
-
-		// -(void)logout;
-		[Export("logout")]
-		void Logout();
-
-		// -(void)loadPage;
-		[Export("loadPage")]
-		void LoadPage();
-	}
-
-	// @protocol CSWebViewLoginDelegate <NSObject>
-	[Protocol, Model]
-	[BaseType(typeof(NSObject))]
-	interface CSWebViewLoginDelegate
-	{
-		// @required -(void)csWebViewNeedsOauthToken:(CSWebView *)webView;
-		[Abstract]
-		[Export("csWebViewNeedsOauthToken:")]
-		void CsWebViewNeedsOauthToken(CSWebView webView);
-
-		// @required -(void)csWebViewUserLoggedOut:(CSWebView *)webView;
-		[Abstract]
-		[Export("csWebViewUserLoggedOut:")]
-		void CsWebViewUserLoggedOut(CSWebView webView);
-
-		// @required -(void)csWebViewTokenValidationFailed:(CSWebView *)webView error:(id)errorCode;
-		[Abstract]
-		[Export("csWebViewTokenValidationFailed:error:")]
-		void CsWebViewTokenValidationFailed(CSWebView webView, NSObject errorCode);
-	}
-
-	// @protocol CSWebViewAnalyticsDelegate <NSObject>
-	[Protocol, Model]
-	[BaseType(typeof(NSObject))]
-	interface CSWebViewAnalyticsDelegate
-	{
-		// @required -(void)csWebView:(CSWebView *)csWebView taggedEvent:(NSString *)eventName properties:(NSDictionary *)eventProperties;
-		[Abstract]
-		[Export("csWebView:taggedEvent:properties:")]
-		void TaggedEvent(CSWebView csWebView, string eventName, NSDictionary eventProperties);
-
-		// @required -(void)csWebView:(CSWebView *)csWebView taggedScreen:(NSString *)screenName;
-		[Abstract]
-		[Export("csWebView:taggedScreen:")]
-		void TaggedScreen(CSWebView csWebView, string screenName);
-	}
+        // @property (readonly, nonatomic) NSString * _Nullable monitoringSessionUserTrackingIdentifier;
+        [Export("monitoringSessionUserTrackingIdentifier")]
+        string MonitoringSessionUserTrackingIdentifier { get; }
+    }
 
 	// @interface CSWKWebView : WKWebView
     [Protocol]

--- a/src/Curbside.Xamarin.iOS/Properties/AssemblyInfo.cs
+++ b/src/Curbside.Xamarin.iOS/Properties/AssemblyInfo.cs
@@ -7,4 +7,4 @@ using Foundation;
 [assembly: AssemblyDescription("Binding for Curbside's iOS SDK")]
 [assembly: AssemblyCompany("Curbside")]
 [assembly: AssemblyCopyright("2019 Curbside")]
-[assembly: AssemblyVersion("3.27.0")]
+[assembly: AssemblyVersion("3.30.0")]

--- a/src/Curbside.Xamarin.iOS/Structs.cs
+++ b/src/Curbside.Xamarin.iOS/Structs.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using CoreLocation;
 using ObjCRuntime;
 
 namespace Curbside
@@ -17,18 +18,21 @@ namespace Curbside
 	[Native]
 	public enum CSEvent : long
 	{
-		CustomerReady = 1,
-		CustomerIsssueRaised,
-		CustomerIssueResolved,
-		SiteOpsLocatedCustomer,
-		SiteOpsFailedtoLocateCustomer,
-		Internal
-	}
+        UserReady = 1,
+        UserIsssueRaised,
+        UserIssueResolved,
+        LocatedUserAtSite,
+        FailedToLocateUserAtSite,
+        Internal
+    }
 
 	[Native]
 	public enum CSErrorCode : long
 	{
-		InvalidSiteInstance = 1,
+        LocationNotAuthorized = 1,
+        BackgroundAppRefreshDenied,
+        TrackingIdentifierInvalid,
+        InvalidSiteInstance,
         NoTrackTokensForSite,
         APIKeySecretNotSet,
         UsageTokenNotSet,
@@ -40,28 +44,29 @@ namespace Curbside
         Unauthorized,
         TripLimitExceeded,
         TooManySites,
+        TrackTokenAlreadyUsed,
+        InvalidLocation,
         Unknown
-	}
+    }
 
 	[Native]
 	public enum CSUserStatus : long
 	{
-		Unknown = 0,
-		InTransit,
-		Approaching,
-		Arrived,
-		UserInitiatedArrived
-	}
+        Unknown = 0,
+        InTransit,
+        Approaching,
+        Arrived,
+        UserInitiatedArrived
+    }
 
     [Native]
-	public enum CSUserSessionAction : long
+    public enum CSMotionActivity : long
     {
-        UpdateTrackedSites = 1,
-        StartTrack,
-        StopTrack,
-        CancelTrack,
-        UpdateLocations,
-        NotifySiteOps
+        Unknown = 0,
+        InVehicle,
+        OnBicycle,
+        OnFoot,
+        Still
     }
 
     [Native]
@@ -69,5 +74,48 @@ namespace Curbside
     {
         Driving = 0,
         Walking
+    }
+
+    [Native]
+    public enum CSUserSessionAction : long
+    {
+        UpdateTrackedSites = 1,
+        StartTrack,
+        StopTrack,
+        CancelTrack,
+        UpdateLocations,
+        NotifyMonitoringSessionUser,
+        EtaToSite
+    }
+
+    public enum CLAuthorizationStatus
+    {
+        NotDetermined = 0,
+        Restricted,
+        Denied,
+        AuthorizedAlways,
+        AuthorizedWhenInUse,
+        Authorized = AuthorizedAlways
+    }
+
+    public enum CLDeviceOrientation
+    {
+        Unknown = 0,
+        Portrait,
+        PortraitUpsideDown,
+        LandscapeLeft,
+        LandscapeRight,
+        FaceUp,
+        FaceDown
+    }
+
+    [Native]
+    public enum CLActivityType : long
+    {
+        Other = 1,
+        AutomotiveNavigation,
+        Fitness,
+        OtherNavigation,
+        Airborne
     }
 }


### PR DESCRIPTION
- Upgraded iOS SDK bindings to `3.30`
- Updated bindings to support iOS 13
- Support a  concept of `user is on their way` trip which is an extra hint to ARRIVE that the user is now heading towards the store. This does not require 'Always' location permission. New method(s) have been added in SDK to support this concept.
- Added support for specifying trip types (“curbside”, “dine-In”, “carry-out”, “drive-thru”. If your business case requires different trip types, please contact your Rakuten Ready rep so we can add yours ). 
- Bluetooth requirement for the SDK has been removed.
